### PR TITLE
Update each build with manifest.json

### DIFF
--- a/replace.sh
+++ b/replace.sh
@@ -7,6 +7,7 @@ rm -rf assets
 rm -rf flutter_service_worker.js
 rm -rf main.dart.js.map
 rm -rf index.html
+rm -rf manifest.json
 
 # Copy files from build
 cp -r build/web/assets .
@@ -15,5 +16,6 @@ cp build/web/flutter_service_worker.js .
 cp build/web/index.html .
 cp build/web/main.dart.js .
 cp build/web/main.dart.js.map .
+cp build/web/manifest.json
 
 echo "Done"


### PR DESCRIPTION
Currently, the lack of a manifest.json shows up as an error in the chrome devtools console:
![image](https://user-images.githubusercontent.com/44558033/82117727-328ca280-9740-11ea-87c2-bbfa76ff466a.png)

More importantly, however, manifest.json is an important file for PWA and it is good practice to include it.